### PR TITLE
Fix path issue to autocomplete widget of jquery-ui.

### DIFF
--- a/finished/src/components/course-control.jsx
+++ b/finished/src/components/course-control.jsx
@@ -1,4 +1,4 @@
-import          'jquery-ui/autocomplete';
+import          'jquery-ui/ui/widgets/autocomplete';
 import React    from 'react';
 import ReactDOM from 'react-dom';
 


### PR DESCRIPTION
When running below command in Windows 7

```
npm run finished
```

we are seeing below error message

```
ERROR in ./finished/src/components/course-control.jsx
Module not found: Error: Cannot resolve module 'jquery-ui/autocomplete' in D:\Doc\Dev\javascript-me\react-under-the-hood-second-edition\finished\src\components
 @ ./finished/src/components/course-control.jsx 11:0-33
webpack: bundle is now VALID.
```

![image](https://cloud.githubusercontent.com/assets/3840439/19717420/1aa4ebca-9b93-11e6-8fa5-e3338652f256.png)

This pull request is to fix this issue. 
